### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+
+setup(
+    name='DAGMM',
+    packages=['dagmm',],
+    license='MIT License',
+    author='Toshihiro NAKAE',
+    description='UNOFFICIAL implementation of the paper Deep Autoencoding Gaussian Mixture Model for Unsupervised Anomaly Detection [Bo Zong et al (2018)]',
+    long_description=open('README.md').read(),
+)


### PR DESCRIPTION
I added a `setup.py` so people can simply use `python setup.py install` to install and start using the DAGMM package.